### PR TITLE
Timer, Stop!

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This produced the following console output:
 213 1433806724409
 ```
 
-Note that the first *elapsed* is 6ms, since this is the elapsed time since the timer started, not the elapsed time since the timer was scheduled.
+Note that the first *elapsed* is 6ms, since this is the elapsed time since the timer started (after the 150ms delay), not the elapsed time since the timer was scheduled.
 
 Use *delay* and *time* to specify relative and absolute moments in time when the *callback* should start being invoked. For example, a calendar notification might be coded as:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you use NPM, `npm install d3-timer`. Otherwise, download the [latest release]
 
 Schedules a new timer, invoking the specified *callback* repeatedly until the timer is [stopped](#timer_stop). An optional numeric *delay* in milliseconds may be specified to invoke the given *callback* after a delay; if *delay* is not specified, it defaults to zero. The delay is relative to the specified *time* in milliseconds since UNIX epoch; if *time* is not specified, it defaults to [Date.now](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/now).
 
-The *callback* is passed two arguments when it is invoked: the elapsed time since the timer became active, and the current time. The latter is useful for precise scheduling of secondary timers. For example:
+The *callback* is passed two arguments when it is invoked: the elapsed time since the timer became active and the current time. The latter is useful for precise scheduling of secondary timers. For example:
 
 ```js
 var t = timer(function(elapsed, time) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you use NPM, `npm install d3-timer`. Otherwise, download the [latest release]
 
 Schedules a new timer, invoking the specified *callback* repeatedly until the timer is [stopped](#timer_stop). An optional numeric *delay* in milliseconds may be specified to invoke the given *callback* after a delay; if *delay* is not specified, it defaults to zero. The delay is relative to the specified *time* in milliseconds since UNIX epoch; if *time* is not specified, it defaults to [Date.now](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/now).
 
-The *callback* is passed two arguments when it is invoked: the elapsed time since the timer became active and the current time. The latter is useful for precise scheduling of secondary timers. For example:
+The *callback* is passed two arguments when it is invoked: the elapsed time since the timer became active, and the current time. The latter is useful for precise scheduling of secondary timers. For example:
 
 ```js
 var t = timer(function(elapsed, time) {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Note that zero-delay timers are normally first executed after one frame (~17ms).
 
 * Returning a truthy value from the timer callback no longer has any effect; use [*timer*.stop](#timer_stop) instead. You can now stop a timer outside its callback.
 
-* The timerReplace method has been replaced by [*timer*.restart](#timer_restart). You can now restart a timer outside its callback.
+* The timerReplace method has been replaced by [*timer*.restart](#timer_restart). You can now restart (replace) a timer outside its callback.
 
 * Timer callbacks are now passed the current time as a second argument, in addition to the elapsed time; this is useful for precise scheduling of secondary timers.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Use *delay* and *time* to specify relative and absolute moments in time when the
 timer(callback, -4 * 1000 * 60 * 60, new Date(2012, 09, 29)); // four hours before midnight October 29 (months are zero-based)
 ```
 
-If [timer](#timer) is called within the callback of another timer, the new timer callback (if eligible as determined by the specified *delay* and *time*) will be invoked immediately at the end of the current frame, rather than waiting until the next frame.
+If [timer](#timer) is called within the callback of another timer, the new timer callback (if eligible as determined by the specified *delay* and *time*) will be invoked immediately at the end of the current frame, rather than waiting until the next frame. Within a frame, timer callbacks are guaranteed to be invoked in the order they were scheduled (regardless of their start time).
 
 <a name="timer_restart" href="#timer_restart">#</a> <i>timer</i>.<b>restart</b>(<i>callback</i>[, <i>delay</i>[, <i>time</i>]])
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you use NPM, `npm install d3-timer`. Otherwise, download the [latest release]
 
 <a name="timer" href="#timer">#</a> <b>timer</b>(<i>callback</i>[, <i>delay</i>[, <i>time</i>]])
 
-Schedules a new timer, invoking the specified *callback* repeatedly until the timer is stopped. An optional numeric *delay* in milliseconds may be specified to invoke the given *callback* after a delay; if *delay* is not specified, it defaults to zero. The delay is relative to the specified *time* in milliseconds since UNIX epoch; if *time* is not specified, it defaults to [Date.now](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/now).
+Schedules a new timer, invoking the specified *callback* repeatedly until the timer is [stopped](#timer_stop). An optional numeric *delay* in milliseconds may be specified to invoke the given *callback* after a delay; if *delay* is not specified, it defaults to zero. The delay is relative to the specified *time* in milliseconds since UNIX epoch; if *time* is not specified, it defaults to [Date.now](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/now).
 
 The *callback* is passed two arguments when it is invoked: the elapsed time since the timer became active, and the current time. The latter is useful for precise scheduling of secondary timers. For example:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If [timer](#timer) is called within the callback of another timer, the new timer
 
 <a name="timer_restart" href="#timer_restart">#</a> <i>timer</i>.<b>restart</b>(<i>callback</i>[, <i>delay</i>[, <i>time</i>]])
 
-Restart a timer with the specified *callback* and optional *delay* and *time*. This is equivalent to stopping this timer and creating a new timer with the specified arguments, although this timer retains the same [id](#timer_id).
+Restart a timer with the specified *callback* and optional *delay* and *time*. This is equivalent to stopping this timer and creating a new timer with the specified arguments, although this timer retains the original [id](#timer_id) and invocation priority.
 
 <a name="timer_stop" href="#timer_stop">#</a> <i>timer</i>.<b>stop</b>()
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ An opaque, unique identifier for this timer.
 
 <a name="timerFlush" href="#timerFlush">#</a> <b>timerFlush</b>([<i>time</i>])
 
-Immediately execute (invoke once) any eligible timer callbacks. If *time* is specified, it represents the current time; if not specified, it defaults to Date.now. Specifying the time explicitly can ensure deterministic behavior.
+Immediately execute (invoke once) any eligible timer callbacks. If *time* is specified, it represents the current time; if not specified, it defaults to Date.now. Specifying an explicit time helps ensure deterministic behavior.
 
 Note that zero-delay timers are normally first executed after one frame (~17ms). This can cause a brief flicker because the browser renders the page twice: once at the end of the first event loop, then again immediately on the first timer callback. By flushing the timer queue at the end of the first event loop, you can run any zero-delay timers immediately and avoid the flicker.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Note that zero-delay timers are normally first executed after one frame (~17ms).
 
 ## Changes from D3 3.x:
 
-* Returning a truthy value from the timer callback no longer has any effect; use [*timer*.stop](#timer_stop) to stop a timer. You can now stop a timer from outside its callback.
+* Returning a truthy value from the timer callback no longer has any effect; use [*timer*.stop](#timer_stop) instead. You can now stop a timer from outside its callback.
 
 * The timerReplace method has been replaced by [*timer*.restart](#timer_restart). You can now restart a timer outside its callback.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Note that zero-delay timers are normally first executed after one frame (~17ms).
 
 ## Changes from D3 3.x:
 
-* Returning a truthy value from the timer callback no longer has any effect; use [*timer*.stop](#timer_stop) instead. You can now stop a timer from outside its callback.
+* Returning a truthy value from the timer callback no longer has any effect; use [*timer*.stop](#timer_stop) instead. You can now stop a timer outside its callback.
 
 * The timerReplace method has been replaced by [*timer*.restart](#timer_restart). You can now restart a timer outside its callback.
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 import {
   timer,
-  timerReplace,
   timerFlush
 } from "./src/timer";
 
 export {
   timer,
-  timerReplace,
   timerFlush
 };

--- a/src/timer.js
+++ b/src/timer.js
@@ -25,7 +25,7 @@ Timer.prototype = timer.prototype = {
     if (t) {
       t.callback = callback, t.time = time;
     } else {
-      t = {next: null, callback: callback, time: time, timer: this};
+      t = {next: null, callback: callback, time: time};
       if (taskTail) taskTail.next = t; else taskHead = t;
       taskById[i] = taskTail = t;
     }
@@ -49,9 +49,9 @@ export function timerFlush(time) {
   time = time == null ? Date.now() : +time;
   ++frame; // Pretend we’ve set an alarm, if we haven’t already.
   try {
-    var t = taskHead;
+    var t = taskHead, c;
     while (t) {
-      if (time >= t.time) t.callback.call(t.timer, time - t.time, time);
+      if (time >= t.time) c = t.callback, c(time - t.time, time);
       t = t.next;
     }
   } finally {

--- a/src/timer.js
+++ b/src/timer.js
@@ -31,7 +31,7 @@ Timer.prototype = {
     sleep(); // Sleep for a tick, and then compute the desired wake time.
   },
   stop: function() {
-    if (this === active) active = this.previous;
+    if (this === active) active = this.previous; // TODO re-entrant timerFlush
     this.previous.next = this.next, this.next.previous = this.previous;
     this.previous = this.next = this.callback = null;
   }

--- a/src/timer.js
+++ b/src/timer.js
@@ -20,6 +20,7 @@ function Timer(callback, delay, time) {
 
 Timer.prototype = timer.prototype = {
   restart: function(callback, delay, time) {
+    if (typeof callback !== "function") throw new TypeError("callback is not a function");
     time = (time == null ? Date.now() : +time) + (delay == null ? 0 : +delay);
     var i = this.id, t = taskById[i];
     if (t) {

--- a/src/timer.js
+++ b/src/timer.js
@@ -1,11 +1,7 @@
-var queueHead = {previous: null, next: null},
-    queueTail = {previous: null, next: null},
-    active, // the currently-executing timer
-    frame, // is an animation frame pending?
-    timeout; // is a timeout pending?
-
-queueHead.next = queueTail;
-queueTail.previous = queueHead;
+var queueHead,
+    queueTail,
+    frame = 0, // is an animation frame pending?
+    timeout = 0; // is a timeout pending?
 
 var setFrame = typeof window !== "undefined"
     && (window.requestAnimationFrame
@@ -18,22 +14,22 @@ var setFrame = typeof window !== "undefined"
 // TODO These fields should be really private, like, inaccessible?
 function Timer(callback, delay, time) {
   this.reset(callback, delay, time);
-  this.previous = queueTail.previous;
-  this.next = queueTail;
-  queueTail.previous.next = this;
-  queueTail.previous = this;
+  this.next = null;
+  if (queueTail) queueTail.next = this;
+  else queueHead = this;
+  queueTail = this;
 }
 
 Timer.prototype = {
   reset: function(callback, delay, time) {
     this.callback = callback;
     this.time = (time == null ? Date.now() : +time) + (delay == null ? 0 : +delay);
-    sleep(); // Sleep for a tick, and then compute the desired wake time.
+    sleep();
   },
   stop: function() {
-    if (this === active) active = this.previous; // TODO re-entrant timerFlush
-    this.previous.next = this.next, this.next.previous = this.previous;
-    this.previous = this.next = this.callback = null;
+    this.callback = null;
+    this.time = Infinity;
+    sleep();
   }
 };
 
@@ -43,16 +39,15 @@ export function timer(callback, delay, time) {
 
 export function timerFlush(time) {
   time = time == null ? Date.now() : +time;
-  var active0 = active;
-  active = queueHead;
+  ++frame;
   try {
-    while ((active = active.next) !== queueTail) {
-      if (time >= active.time) {
-        active.callback(time - active.time, time);
-      }
+    var t = queueHead;
+    while (t) {
+      if (time >= t.time) t.callback(time - t.time, time);
+      t = t.next;
     }
   } finally {
-    active = active0;
+    --frame;
   }
 };
 
@@ -61,20 +56,24 @@ function wake() {
   try {
     timerFlush();
   } finally {
-    var timer = queueHead, time = Infinity;
-    while ((timer = timer.next) !== queueTail) {
-      if (time > timer.time) {
-        time = timer.time;
+    var t0, t1 = queueHead, time = Infinity;
+    while (t1) {
+      if (t1.callback) {
+        if (time > t1.time) time = t1.time;
+        t1 = (t0 = t1).next;
+      } else {
+        t1 = t0 ? t0.next = t1.next : queueHead = t1.next;
       }
     }
+    queueTail = t0;
     sleep(time);
   }
 }
 
 function sleep(time) {
-  if (frame || active) return; // Soonest alarm already set, or will be.
+  if (frame) return; // Soonest alarm already set, or will be.
   if (timeout) timeout = clearTimeout(timeout);
   var delay = time - Date.now();
-  if (delay > 24) timeout = setTimeout(wake, delay);
+  if (delay > 24) { if (time < Infinity) timeout = setTimeout(wake, delay); }
   else frame = setFrame(wake);
 }

--- a/src/timer.js
+++ b/src/timer.js
@@ -83,5 +83,5 @@ function sleep(time) {
   if (timeout) timeout = clearTimeout(timeout);
   var delay = time - Date.now();
   if (delay > 24) { if (time < Infinity) timeout = setTimeout(wake, delay); }
-  else frame = setFrame(wake);
+  else frame = 1, setFrame(wake);
 }

--- a/src/timer.js
+++ b/src/timer.js
@@ -1,9 +1,11 @@
-var queueHead,
-    queueTail,
+var queueHead = {previous: null, next: null},
+    queueTail = {previous: null, next: null},
     active, // the currently-executing timer
     frame, // is an animation frame pending?
-    timeout, // is a timeout pending?
-    timeoutTime = Infinity; // the time the timeout will fire
+    timeout; // is a timeout pending?
+
+queueHead.next = queueTail;
+queueTail.previous = queueHead;
 
 var setFrame = typeof window !== "undefined"
     && (window.requestAnimationFrame
@@ -13,77 +15,66 @@ var setFrame = typeof window !== "undefined"
       || window.oRequestAnimationFrame)
       || function(callback) { return setTimeout(callback, 17); };
 
-// The timer will continue to fire until callback returns true.
+// TODO These fields should be really private, like, inaccessible?
+function Timer(callback, delay, time) {
+  this.reset(callback, delay, time);
+  this.previous = queueTail.previous;
+  this.next = queueTail;
+  queueTail.previous.next = this;
+  queueTail.previous = this;
+}
+
+Timer.prototype = {
+  reset: function(callback, delay, time) {
+    this.callback = callback;
+    this.time = (time == null ? Date.now() : +time) + (delay == null ? 0 : +delay);
+    sleep(); // Sleep for a tick, and then compute the desired wake time.
+  },
+  stop: function() {
+    if (this === active) active = this.previous;
+    this.previous.next = this.next, this.next.previous = this.previous;
+    this.previous = this.next = this.callback = null;
+  }
+};
+
 export function timer(callback, delay, time) {
-  time = time == null ? Date.now() : +time;
-  if (delay != null) time += +delay;
-
-  // Add the callback to the tail of the queue.
-  var timer = {callback: callback, time: time, flush: false, next: null};
-  if (queueTail) queueTail.next = timer;
-  else queueHead = timer;
-  queueTail = timer;
-
-  // Set an alarm to wake up for the timer’s first tick, if necessary.
-  if (!frame && !active) wakeAt(time);
+  return new Timer(callback, delay, time);
 };
 
-// Replace the current timer. Only allowed within a timer callback.
-export function timerReplace(callback, delay, time) {
-  time = time == null ? Date.now() : +time;
-  if (delay != null) time += +delay;
-  active.callback = callback;
-  active.time = time;
-};
-
-// Execute all eligible timers,
-// then flush completed timers to avoid concurrent queue modification.
-// Returns the time of the earliest active timer.
 export function timerFlush(time) {
   time = time == null ? Date.now() : +time;
   var active0 = active;
-
-  // Note: timerFlush can be re-entrant, so we must preserve the old active.
   active = queueHead;
-  while (active) {
-    if (time >= active.time) active.flush = active.callback(time - active.time, time);
-    active = active.next;
-  }
-  active = active0;
-  time = Infinity;
-
-  // Note: invoking a timer callback can change the timer queue (due to a re-
-  // entrant timerFlush or scheduling a new timer). Thus we must defer capturing
-  // queueHead until after we’ve invoked all callbacks.
-  var t0,
-      t1 = queueHead;
-  while (t1) {
-    if (t1.flush) {
-      t1 = t0 ? t0.next = t1.next : queueHead = t1.next;
-    } else {
-      if (t1.time < time) time = t1.time;
-      t1 = (t0 = t1).next;
+  try {
+    while ((active = active.next) !== queueTail) {
+      if (time >= active.time) {
+        active.callback(time - active.time, time);
+      }
     }
+  } finally {
+    active = active0;
   }
-  queueTail = t0;
-  return time;
 };
 
 function wake() {
-  frame = timeout = 0, timeoutTime = Infinity;
-  wakeAt(timerFlush());
+  frame = timeout = 0;
+  try {
+    timerFlush();
+  } finally {
+    var timer = queueHead, time = Infinity;
+    while ((timer = timer.next) !== queueTail) {
+      if (time > timer.time) {
+        time = timer.time;
+      }
+    }
+    sleep(time);
+  }
 }
 
-function wakeAt(time) {
+function sleep(time) {
+  if (frame || active) return; // Soonest alarm already set, or will be.
+  if (timeout) timeout = clearTimeout(timeout);
   var delay = time - Date.now();
-  if (delay > 24) {
-    if (timeoutTime > time) { // Note: false if time is infinite.
-      if (timeout) clearTimeout(timeout);
-      timeout = setTimeout(wake, delay);
-      timeoutTime = time;
-    }
-  } else {
-    if (timeout) timeout = clearTimeout(timeout), timeoutTime = Infinity;
-    frame = setFrame(wake);
-  }
+  if (delay > 24) timeout = setTimeout(wake, delay);
+  else frame = setFrame(wake);
 }

--- a/test/timer-test.js
+++ b/test/timer-test.js
@@ -8,32 +8,32 @@ tape("timer(callback) invokes the callback in about 17ms", function(test) {
   timer.timer(function() {
     test.inRange(Date.now() - start, 17 - 10, 17 + 10);
     test.end();
-    return true;
+    this.stop();
   });
 });
 
 tape("timer(callback) invokes callbacks in scheduling order within a frame", function(test) {
   var results = [];
-  timer.timer(function() { results.push(1); return true; });
-  timer.timer(function() { results.push(2); return true; });
-  timer.timer(function() { results.push(3); return true; });
+  timer.timer(function() { results.push(1); this.stop(); });
+  timer.timer(function() { results.push(2); this.stop(); });
+  timer.timer(function() { results.push(3); this.stop(); });
   timer.timer(function() {
     test.deepEqual(results, [1, 2, 3]);
     test.end();
-    return true;
+    this.stop();
   });
 });
 
 tape("timer(callback, delay) invokes callbacks in scheduling order within a frame", function(test) {
   var start = Date.now(),
       results = [];
-  timer.timer(function() { results.push(1); return true; }, 100, start);
-  timer.timer(function() { results.push(2); return true; }, 100, start);
-  timer.timer(function() { results.push(3); return true; }, 100, start);
+  timer.timer(function() { results.push(1); this.stop(); }, 100, start);
+  timer.timer(function() { results.push(2); this.stop(); }, 100, start);
+  timer.timer(function() { results.push(3); this.stop(); }, 100, start);
   timer.timer(function() {
     test.deepEqual(results, [1, 2, 3]);
     test.end();
-    return true;
+    this.stop();
   }, 100, start);
 });
 
@@ -43,7 +43,7 @@ tape("timer(callback) invokes the callback about every 17ms until it returns tru
     if (++count > 10) {
       test.inRange(Date.now() - start, 170 - 100, 170 + 100);
       test.end();
-      return true;
+      this.stop();
     }
   });
 });
@@ -53,7 +53,7 @@ tape("timer(callback) invokes the callback until it returns a truthy value", fun
   timer.timer(function() {
     if (++count > 2) {
       test.end();
-      return 1;
+      this.stop();
     }
   });
 });
@@ -65,7 +65,7 @@ tape("timer(callback) passes the callback the elapsed and current time", functio
     test.inRange(now, Date.now() - 10, Date.now());
     if (++count > 10) {
       test.end();
-      return true;
+      this.stop();
     }
   }, 0, start);
 });
@@ -79,9 +79,9 @@ tape("timer(callback) within a callback invokes the new callback within the same
       test.equal(now2, now);
       test.inRange(Date.now() - start, delay, delay + 3);
       test.end();
-      return true;
+      this.stop();
     }, 0, now);
-    return true;
+    this.stop();
   });
 });
 
@@ -90,7 +90,7 @@ tape("timer(callback, delay) first invokes the callback after the specified dela
   timer.timer(function() {
     test.inRange(Date.now() - start, delay - 10, delay + 10);
     test.end();
-    return true;
+    this.stop();
   }, delay);
 });
 
@@ -99,7 +99,7 @@ tape("timer(callback, delay) computes the elapsed time relative to the delay", f
   timer.timer(function(elapsed) {
     test.inRange(elapsed, 0, 10);
     test.end();
-    return true;
+    this.stop();
   }, delay);
 });
 
@@ -108,7 +108,7 @@ tape("timer(callback, delay, time) computes the effective delay relative to the 
   timer.timer(function(elapsed) {
     test.inRange(elapsed, skew - delay + 17 - 10, skew - delay + 17 + 10);
     test.end();
-    return true;
+    this.stop();
   }, delay, Date.now() - skew);
 });
 
@@ -123,11 +123,11 @@ tape("timer(callback, delay) within a timerFlush() does not schedule a duplicate
         setTimeout = setTimeout0;
         test.equal(frames, 2);
         test.end();
-        return true;
+        this.stop();
       }, 10);
-      return true;
+      this.stop();
     }, 10);
-    return true;
+    this.stop();
   });
   timer.timerFlush();
 });
@@ -143,11 +143,11 @@ tape("timer(callback) within a timerFlush() does not schedule a duplicate reques
         setTimeout = setTimeout0;
         test.equal(frames, 1);
         test.end();
-        return true;
+        this.stop();
       }, 0, time);
-      return true;
+      this.stop();
     }, 0, time);
-    return true;
+    this.stop();
   });
   timer.timerFlush();
 });
@@ -169,11 +169,11 @@ tape("timer(callback) switches to setTimeout for long delays", function(test) {
         test.equal(timeouts, 2);
         setTimeout = setTimeout0;
         test.end();
-        return true;
+        this.stop();
       }, 100);
-      return true;
+      this.stop();
     }, 10);
-    return true;
+    this.stop();
   }, 100);
 });
 
@@ -191,13 +191,13 @@ tape("timer(callback) cancels an earlier setTimeout as appropriate", function(te
     setTimeout = setTimeout0;
     clearTimeout = clearTimeout0;
     test.end();
-    return true;
+    this.stop();
   }, 150);
   timer.timer(function() {
     test.equal(clearTimeouts.length, 1);
     test.equal(setTimeouts.length, 2);
     test.equal(clearTimeouts[0], setTimeouts[0]);
-    return true;
+    this.stop();
   }, 100);
 });
 
@@ -212,7 +212,7 @@ tape("timer(callback) reuses an earlier setTimeout as appropriate", function(tes
   timer.timer(function() {
     test.equal(clearTimeouts.length, 0);
     test.equal(setTimeouts.length, 1);
-    return true;
+    this.stop();
   }, 100);
   timer.timer(function() {
     test.equal(clearTimeouts.length, 0);
@@ -220,13 +220,13 @@ tape("timer(callback) reuses an earlier setTimeout as appropriate", function(tes
     setTimeout = setTimeout0;
     clearTimeout = clearTimeout0;
     test.end();
-    return true;
+    this.stop();
   }, 150);
 });
 
 tape("timerFlush() immediately invokes any eligible timers", function(test) {
   var count = 0;
-  timer.timer(function() { return ++count; });
+  timer.timer(function() { if (++count) this.stop(); });
   timer.timerFlush();
   timer.timerFlush();
   test.equal(count, 1);
@@ -235,7 +235,7 @@ tape("timerFlush() immediately invokes any eligible timers", function(test) {
 
 tape("timerFlush() within timerFlush() still executes all eligible timers", function(test) {
   var count = 0;
-  timer.timer(function() { if (++count >= 3) return true; timer.timerFlush(); });
+  timer.timer(function() { if (++count >= 3) this.stop(); timer.timerFlush(); });
   timer.timerFlush();
   test.equal(count, 3);
   test.end();
@@ -243,7 +243,7 @@ tape("timerFlush() within timerFlush() still executes all eligible timers", func
 
 tape("timerFlush(time) observes the specified time", function(test) {
   var start = Date.now(), count = 0;
-  timer.timer(function() { return ++count >= 2; }, 0, start);
+  timer.timer(function() { if (++count >= 2) this.stop(); }, 0, start);
   timer.timerFlush(start - 1);
   test.equal(count, 0);
   timer.timerFlush(start);

--- a/test/timer-test.js
+++ b/test/timer-test.js
@@ -18,6 +18,13 @@ tape("timer(callback) returns an instanceof timer", function(test) {
   end(test);
 });
 
+tape("timer(callback) verifies that callback is a function", function(test) {
+  test.throws(function() { timer.timer(); }, TypeError);
+  test.throws(function() { timer.timer("42"); }, TypeError);
+  test.throws(function() { timer.timer(null); }, TypeError);
+  test.end();
+});
+
 // It’s difficult to test the timing behavior reliably, since there can be small
 // hiccups that cause a timer to be delayed. So we test only the mean rate.
 tape("timer(callback) invokes the callback about every 17ms", function(test) {
@@ -323,7 +330,25 @@ tape("timer.stop() recomputes the new wake time after one frame", function(test)
   }, 100);
 });
 
-tape("timer.restart() recomputes the new wake time after one frame", function(test) {
+tape("timer.restart(callback) verifies that callback is a function", function(test) {
+  var t = timer.timer(function() {});
+  test.throws(function() { t.restart(); }, TypeError);
+  test.throws(function() { t.restart(null); }, TypeError);
+  test.throws(function() { t.restart("42"); }, TypeError);
+  t.stop();
+  end(test);
+});
+
+tape("timer.restart(callback) implicitly uses zero delay and the current time", function(test) {
+  var t = timer.timer(function() {}, 1000);
+  t.restart(function(elapsed) {
+    test.inRange(elapsed, 17 - 10, 17 + 10);
+    t.stop();
+    end(test);
+  });
+});
+
+tape("timer.restart(callback, delay, time) recomputes the new wake time after one frame", function(test) {
   var then = Date.now(),
       setTimeout0 = setTimeout,
       delays = [];
@@ -368,6 +393,14 @@ tape("timer.restart() recomputes the new wake time after one frame", function(te
       }, 100);
     }, 100);
   }, 100);
+});
+
+tape("timer.id is a positive integer", function(test) {
+  var t = timer.timer(function() {});
+  test.ok(t.id > 0);
+  test.equal(t.id % 1, 0);
+  t.stop();
+  end(test);
 });
 
 tape("timerFlush() immediately invokes any eligible timers", function(test) {

--- a/test/timer-test.js
+++ b/test/timer-test.js
@@ -4,111 +4,121 @@ var tape = require("tape"),
 require("./inRange");
 
 tape("timer(callback) invokes the callback in about 17ms", function(test) {
-  var start = Date.now();
-  timer.timer(function() {
-    test.inRange(Date.now() - start, 17 - 10, 17 + 10);
+  var t = timer.timer(function(elapsed) {
+    test.inRange(elapsed, 17 - 10, 17 + 10);
     test.end();
-    this.stop();
+    t.stop();
   });
+});
+
+tape("timer(callback) passes the callback the elapsed and current time", function(test) {
+  var then = Date.now();
+  var t = timer.timer(function(elapsed, now) {
+    test.inRange(now, Date.now() - 5, Date.now());
+    test.equal(elapsed, now - then);
+    test.end();
+    t.stop();
+  }, 0, then);
 });
 
 tape("timer(callback) invokes callbacks in scheduling order within a frame", function(test) {
   var results = [];
-  timer.timer(function() { results.push(1); this.stop(); });
-  timer.timer(function() { results.push(2); this.stop(); });
-  timer.timer(function() { results.push(3); this.stop(); });
-  timer.timer(function() {
+  var t0 = timer.timer(function() { results.push(1); t0.stop(); });
+  var t1 = timer.timer(function() { results.push(2); t1.stop(); });
+  var t2 = timer.timer(function() { results.push(3); t2.stop(); });
+  var t3 = timer.timer(function() {
     test.deepEqual(results, [1, 2, 3]);
     test.end();
-    this.stop();
+    t3.stop();
   });
 });
 
 tape("timer(callback, delay) invokes callbacks in scheduling order within a frame", function(test) {
-  var start = Date.now(),
-      results = [];
-  timer.timer(function() { results.push(1); this.stop(); }, 100, start);
-  timer.timer(function() { results.push(2); this.stop(); }, 100, start);
-  timer.timer(function() { results.push(3); this.stop(); }, 100, start);
-  timer.timer(function() {
+  var then = Date.now(), results = [];
+  var t0 = timer.timer(function() { results.push(1); t0.stop(); }, 100, then);
+  var t1 = timer.timer(function() { results.push(2); t1.stop(); }, 100, then);
+  var t2 = timer.timer(function() { results.push(3); t2.stop(); }, 100, then);
+  var t3 = timer.timer(function() {
     test.deepEqual(results, [1, 2, 3]);
     test.end();
-    this.stop();
-  }, 100, start);
+    t3.stop();
+  }, 100, then);
 });
 
-tape("timer(callback) invokes the callback about every 17ms until it returns true", function(test) {
+tape("timer(callback) invokes the callback about every 17ms", function(test) {
   var start = Date.now(), count = 0;
-  timer.timer(function() {
-    if (++count > 10) {
-      test.inRange(Date.now() - start, 170 - 100, 170 + 100);
+  var t = timer.timer(function() {
+    if (++count >= 10) {
+      test.inRange(Date.now() - start, 170 - 50, 170 + 50);
       test.end();
-      this.stop();
+      t.stop();
     }
   });
 });
 
-tape("timer(callback) invokes the callback until it returns a truthy value", function(test) {
+tape("timer(callback) invokes the callback until the timer is stopped", function(test) {
   var count = 0;
-  timer.timer(function() {
+  var t = timer.timer(function() {
     if (++count > 2) {
       test.end();
-      this.stop();
+      t.stop();
     }
   });
 });
 
 tape("timer(callback) passes the callback the elapsed and current time", function(test) {
   var start = Date.now(), count = 0;
-  timer.timer(function(elapsed, now) {
+  var t = timer.timer(function(elapsed, now) {
     test.equal(elapsed, now - start);
     test.inRange(now, Date.now() - 10, Date.now());
     if (++count > 10) {
       test.end();
-      this.stop();
+      t.stop();
     }
   }, 0, start);
 });
 
+// TODO test that timer(callback, 0, time) during flush runs at the end of the tick
+// TODO should check the number of frames requested here
 tape("timer(callback) within a callback invokes the new callback within the same frame", function(test) {
   var start = Date.now();
-  timer.timer(function(elapsed, now) {
+  var t0 = timer.timer(function(elapsed, now) {
     var delay = Date.now() - start;
-    timer.timer(function(elapsed2, now2) {
+    var t1 = timer.timer(function(elapsed2, now2) {
       test.equal(elapsed2, 0);
       test.equal(now2, now);
       test.inRange(Date.now() - start, delay, delay + 3);
       test.end();
-      this.stop();
+      t1.stop();
     }, 0, now);
-    this.stop();
+    t0.stop();
   });
 });
 
 tape("timer(callback, delay) first invokes the callback after the specified delay", function(test) {
   var start = Date.now(), delay = 150;
-  timer.timer(function() {
+  var t = timer.timer(function() {
     test.inRange(Date.now() - start, delay - 10, delay + 10);
     test.end();
-    this.stop();
+    t.stop();
   }, delay);
 });
 
 tape("timer(callback, delay) computes the elapsed time relative to the delay", function(test) {
   var delay = 150;
-  timer.timer(function(elapsed) {
+  var t = timer.timer(function(elapsed) {
     test.inRange(elapsed, 0, 10);
     test.end();
-    this.stop();
+    t.stop();
   }, delay);
 });
 
 tape("timer(callback, delay, time) computes the effective delay relative to the specified time", function(test) {
   var delay = 150, skew = 200;
-  timer.timer(function(elapsed) {
+  var t = timer.timer(function(elapsed) {
     test.inRange(elapsed, skew - delay + 17 - 10, skew - delay + 17 + 10);
     test.end();
-    this.stop();
+    t.stop();
   }, delay, Date.now() - skew);
 });
 
@@ -118,18 +128,18 @@ tape("timer(callback, delay) within a timerFlush() does not request duplicate fr
       frames = 0;
   setTimeout = function() { ++frames; return setTimeout0.apply(this, arguments); };
 
-  timer.timer(function(elapsed, time) {
+  var t0 = timer.timer(function(elapsed, time) {
 
     // 2. The first timer is invoked synchronously by timerFlush, so only the
     // first frame—when this timer was created—has been requested.
     test.equal(frames, 1);
 
-    this.stop();
+    t0.stop();
 
     // 3. This timer was stopped during flush, so it doesn’t request a frame.
     test.equal(frames, 1);
 
-    timer.timer(function() {
+    var t1 = timer.timer(function() {
 
       // 6. Still only one frame has been requested so far: the second timer has
       // a <17ms delay, and so was called back during the first frame requested
@@ -137,7 +147,7 @@ tape("timer(callback, delay) within a timerFlush() does not request duplicate fr
       // it might need another frame (or timeout) before invocation.
       test.equal(frames, 1);
 
-      this.stop();
+      t1.stop();
 
       // 7. Stopping the second timer doesn’t immediately request a frame since
       // we’re now within an implicit flush (initiated by this timer).
@@ -169,7 +179,6 @@ tape("timer(callback, delay) within a timerFlush() does not request duplicate fr
   test.equal(frames, 1);
 });
 
-// TODO test that timer(callback, 0, time) during flush runs at the end of the tick
 // TODO test that timer.stop outside of flush requests a frame
 // TODO test that timer.restart outside of flush requests a frame
 // TODO test that multipler timer(…) schedulings only requests one frame
@@ -183,27 +192,27 @@ tape("timer(callback) switches to setTimeout for long delays", function(test) {
       timeouts = 0;
   setTimeout = function(callback, delay) { delay === 17 ? ++frames : ++timeouts; return setTimeout0.apply(this, arguments); }; // calls setTimeout
 
-  timer.timer(function() {
+  var t0 = timer.timer(function() {
 
     // 2. The first timer had a delay >24ms, so after the first scheduling
     // frame, we used a longer timeout to wake up.
     test.equal(frames, 1);
     test.equal(timeouts, 1);
 
-    this.stop();
+    t0.stop();
 
     // 3. Stopping a timer during flush doesn’t request a new frame.
     test.equal(frames, 1);
     test.equal(timeouts, 1);
 
-    timer.timer(function() {
+    var t1 = timer.timer(function() {
 
       // 5. The second timer had a short delay, so it’s not immediately invoked
       // during the same tick as the first timer; it gets a new frame.
       test.equal(frames, 2);
       test.equal(timeouts, 1);
 
-      this.stop();
+      t1.stop();
 
       // 6. Stopping a timer during flush doesn’t request a new frame.
       test.equal(frames, 2);
@@ -283,7 +292,7 @@ tape("timer(callback) switches to setTimeout for long delays", function(test) {
 
 tape("timerFlush() immediately invokes any eligible timers", function(test) {
   var count = 0;
-  timer.timer(function() { ++count; this.stop(); });
+  var t = timer.timer(function() { ++count; t.stop(); });
   timer.timerFlush();
   timer.timerFlush();
   test.equal(count, 1);
@@ -292,7 +301,7 @@ tape("timerFlush() immediately invokes any eligible timers", function(test) {
 
 tape("timerFlush() within timerFlush() still executes all eligible timers", function(test) {
   var count = 0;
-  timer.timer(function() { if (++count >= 3) this.stop(); timer.timerFlush(); });
+  var t = timer.timer(function() { if (++count >= 3) t.stop(); timer.timerFlush(); });
   timer.timerFlush();
   test.equal(count, 3);
   test.end();
@@ -300,7 +309,7 @@ tape("timerFlush() within timerFlush() still executes all eligible timers", func
 
 tape("timerFlush(time) observes the specified time", function(test) {
   var start = Date.now(), count = 0;
-  timer.timer(function() { if (++count >= 2) this.stop(); }, 0, start);
+  var t = timer.timer(function() { if (++count >= 2) t.stop(); }, 0, start);
   timer.timerFlush(start - 1);
   test.equal(count, 0);
   timer.timerFlush(start);

--- a/test/timer-test.js
+++ b/test/timer-test.js
@@ -226,7 +226,7 @@ tape("timer(callback) reuses an earlier setTimeout as appropriate", function(tes
 
 tape("timerFlush() immediately invokes any eligible timers", function(test) {
   var count = 0;
-  timer.timer(function() { if (++count) this.stop(); });
+  timer.timer(function() { ++count; this.stop(); });
   timer.timerFlush();
   timer.timerFlush();
   test.equal(count, 1);

--- a/test/timer-test.js
+++ b/test/timer-test.js
@@ -41,6 +41,14 @@ tape("timer(callback) invokes the callback until the timer is stopped", function
   });
 });
 
+tape("timer(callback) uses the global context for the callback", function(test) {
+  var t = timer.timer(function() {
+    test.equal(this, global);
+    t.stop();
+    end(test);
+  });
+});
+
 tape("timer(callback) passes the callback the elapsed and current time", function(test) {
   var start = Date.now(), count = 0;
   var t = timer.timer(function(elapsed, now) {

--- a/test/timer-test.js
+++ b/test/timer-test.js
@@ -121,7 +121,7 @@ tape("timer(callback, delay) within a timerFlush() does not schedule a duplicate
     timer.timer(function() {
       timer.timer(function() {
         setTimeout = setTimeout0;
-        test.equal(frames, 2);
+        test.equal(frames, 4);
         test.end();
         this.stop();
       }, 10);


### PR DESCRIPTION
Rather than stopping timers by having the timer callback return true, timer(…) now returns a timer object with a stop method. Thus, you can now stop a timer synchronously outside of its callback, rather than having to wait until the timer is next called back. This will be useful for synchronously canceling transitions (d3/d3-transition#9 mbostock/d3#2189 mbostock/d3#2211). You can also reset a timer (changing its start time or callback) externally, too. Fixes #5.

For the sake of parsimony, timer.stop is now the only way to stop a timer: returning true from the callback has no effect.

This commit also wraps timer execution with a try-finally block. Fixes #4.

This commit also changes the sleep timing logic slightly. Rather than trying to compute the exact minimum wake-up time whenever a timer is scheduled, we simply make a pessimistic assumption and schedule the shortest nap (using requestAnimationFrame); on the next tick, we’ll compute the exact wake-up time. This has the advantage of avoiding timeout thrashing (setTimeout followed by clearTimeout, repeatedly) if a series of timers are scheduled with descending delays. Similarly, when a timer is stopped, we don’t bother to recalculate the minimum wake-up time, since it can only increase.

TODO
- [x] implement timer.stop
- [x] implement timer.restart
- [x] hide internal fields (next, etc.)
- [x] allow timer.callback to be set directly (no)?
- [x] do we need queueHead and queueTail to be objects (no)? or is null better (yes)?
- [x] rename timer.reset to timer.restart and allow stopped timer to be restarted
- [x] fix timer.stop during re-entrant timerFlush (defer deletion until after flush?)
- [x] fix tests that assume implementation details that have changed
- [x] test timer.stop
- [x] test timer.restart
- [x] test instanceof timer
- [x] update documentation
