### PR TITLE
Fix incorrect time now in Safari iOS 8

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -64,8 +64,8 @@ export function timerFlush() {
   --frame;
 }
 
-function wake(time) {
-  clockNow = (clockLast = time || clock.now()) + clockSkew;
+function wake() {
+  clockNow = (clockLast = clock.now()) + clockSkew;
   frame = timeout = 0;
   try {
     timerFlush();


### PR DESCRIPTION
In Safari iOS 8, `requestAnimationFrame` is present but `performance.now` is not.

So, inconsistent of time "now" will happen since we rely on both `time` passed in by `requestAnimationFrame` (time since navigationStart) and Date.now() (time since epoch) in other cases.

With this changeset, I am calling `performance.now` unnecessarily on mordern browsers on every `wake()` though :confused: 