### PR TITLE
Record clock before sleeping.

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -106,7 +106,7 @@ function sleep(time) {
     if (time < Infinity) timeout = setTimeout(wake, delay);
     if (interval) interval = clearInterval(interval);
   } else {
-    if (!interval) interval = setInterval(poke, pokeDelay);
+    if (!interval) clockLast = clockNow, interval = setInterval(poke, pokeDelay);
     frame = 1, setFrame(wake);
   }
 }


### PR DESCRIPTION
The poke interval was relying on the wake callback to record the last-seen clock time, clockLast. If no timers were run before sleeping (such as when no timers are run immediately on load, but timers are scheduled during a timeout), clockLast was still its initial value, zero. Now we set clockLast to clockNow before scheduling the poke interval, so that it detects skew relative to the time the poke interval was started.

Fixes #17. 