### PR TITLE
Workaround for "Invalid Calling Object" error in IE when using Hot Loader

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -8,7 +8,7 @@ var frame = 0, // is an animation frame pending?
     clockNow = 0,
     clockSkew = 0,
     clock = typeof performance === "object" && performance.now ? performance : Date,
-    setFrame = typeof requestAnimationFrame === "function" ? requestAnimationFrame : function(f) { setTimeout(f, 17); };
+    setFrame = typeof requestAnimationFrame === "function" ? requestAnimationFrame.bind(window) : function(f) { setTimeout(f, 17); };
 
 export function now() {
   return clockNow || (setFrame(clearNow), clockNow = clock.now() + clockSkew);


### PR DESCRIPTION
Hey there,

This is a small patch that fixes the above error in IE/Edge, see the below PR on another repo for reference.

https://github.com/facebook/fixed-data-table/pull/195/files