### PR TITLE
Fix #27 - inaccurate timeout delay.

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -101,10 +101,10 @@ function sleep(time) {
   if (timeout) timeout = clearTimeout(timeout);
   var delay = time - clockNow;
   if (delay > 24) {
-    if (time < Infinity) timeout = setTimeout(wake, delay);
+    if (time < Infinity) timeout = setTimeout(wake, time - clock.now() - clockSkew);
     if (interval) interval = clearInterval(interval);
   } else {
-    if (!interval) clockLast = clockNow, interval = setInterval(poke, pokeDelay);
+    if (!interval) clockLast = clock.now(), interval = setInterval(poke, pokeDelay);
     frame = 1, setFrame(wake);
   }
 }


### PR DESCRIPTION
If timers are expensive, then by the time we sleep, the current time may have advanced substantially from the `clockNow` computed on wake. Therefore we must recompute the current time before scheduling the timeout.