### PR TITLE
Allow mocking of 'requestAnimationFrame'

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -8,7 +8,7 @@ var frame = 0, // is an animation frame pending?
     clockNow = 0,
     clockSkew = 0,
     clock = typeof performance === "object" && performance.now ? performance : Date,
-    setFrame = typeof window === "object" && window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : function(f) { setTimeout(f, 17); };
+    setFrame = typeof window === "object" && window.requestAnimationFrame ? function(f) { window.requestAnimationFrame(f); } : function(f) { setTimeout(f, 17); };
 
 export function now() {
   return clockNow || (setFrame(clearNow), clockNow = clock.now() + clockSkew);


### PR DESCRIPTION
Hey, this is quite a minor change -- I'm fine if you don't take it.

However, we've found (in Power BI visual development) that mocking `requestAnimationFrame()` allows us to "speed" through d3.transitions() in our unit tests.  We've made this change locally for our d3's distribution, I thought it might be useful to share here.

We use jasmine's clock to tick forward in time.  We also use a "Scheduler" class to mock RAF to execute immediately, so we also make this change in the d3 source.  Again, this is a "testability"-only change.